### PR TITLE
Support document variables substitution in paths

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -1,5 +1,6 @@
 <?xml version="1.0" encoding="UTF-8" ?>
-<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 https://maven.apache.org/xsd/maven-4.0.0.xsd">
+<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+         xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 https://maven.apache.org/xsd/maven-4.0.0.xsd">
 
     <modelVersion>4.0.0</modelVersion>
 
@@ -68,15 +69,16 @@
             <scope>provided</scope>
         </dependency>
         <dependency>
-            <groupId>org.junit.jupiter</groupId>
-            <artifactId>junit-jupiter-api</artifactId>
-            <version>5.7.0-RC1</version>
-            <scope>test</scope>
-        </dependency>
-        <dependency>
             <groupId>org.assertj</groupId>
             <artifactId>assertj-core</artifactId>
             <version>3.16.1</version>
+            <scope>test</scope>
+        </dependency>
+        <dependency>
+            <groupId>org.junit.jupiter</groupId>
+            <artifactId>junit-jupiter-engine</artifactId>
+            <version>5.7.0-RC1</version>
+            <scope>test</scope>
         </dependency>
     </dependencies>
 
@@ -95,6 +97,12 @@
                 </plugin>
             </plugins>
         </pluginManagement>
+        <plugins>
+            <plugin>
+                <artifactId>maven-surefire-plugin</artifactId>
+                <version>3.0.0-M5</version>
+            </plugin>
+        </plugins>
     </build>
 
     <distributionManagement>

--- a/src/test/java/io/whelk/asciidoc/TemplateMojoTest.java
+++ b/src/test/java/io/whelk/asciidoc/TemplateMojoTest.java
@@ -1,9 +1,9 @@
 package io.whelk.asciidoc;
 
 import io.whelk.asciidoc.TemplateMojo.PathAndOptions;
-
 import org.junit.jupiter.api.Test;
 
+import java.util.List;
 import java.util.Map;
 
 import static org.assertj.core.api.Assertions.assertThat;
@@ -15,7 +15,7 @@ public class TemplateMojoTest {
     // end::exampleShort[]
 
     @Test
-    void testFilePathExtraction() {
+    void filePathExtraction() {
         TemplateMojo templateMojo = new TemplateMojo();
 
         assertThat(templateMojo.extractPathAndOptions("include::otherFile.adoc[]"))
@@ -32,6 +32,40 @@ public class TemplateMojoTest {
 
         assertThat(templateMojo.updateIncludeLine("include::src/test/java/io/whelk/asciidoc/TemplateMojoTest.java[tag=exampleShort]"))
                 .containsOnly("    String test = \"this is a small test\";");
+    }
+
+    @Test
+    void loadVars() {
+        TemplateMojo templateMojo = new TemplateMojo();
+        Map<String, String> vars = templateMojo.loadVars(List.of(
+                "My Doc",
+                "::",
+                "",
+                ":: 2",
+                ":myVar: 4",
+                ":noSpace:5",
+                ":baseDir: relativeDirectory",
+                "some content",
+                ":Here you can see a weirdly used colon",
+                ":dash-var: dv"
+        ));
+        Map<String, String> expected = Map.of(
+                "myVar", "4",
+                "noSpace", "5",
+                "baseDir", "relativeDirectory",
+                "dash-var", "dv");
+        assertThat(vars).containsExactlyInAnyOrderEntriesOf(expected);
+    }
+
+    @Test
+    void variableInPath() {
+        TemplateMojo templateMojo = new TemplateMojo();
+        Map<String, String> vars = templateMojo.loadVars(List.of(":rootDir: rootHere",
+                ":another: hereAlso"));
+        templateMojo.vars = vars;
+
+        assertThat(templateMojo.extractPathAndOptions("include::{rootDir}/{another}/intoThis[]").getPath())
+                .isEqualTo("rootHere/hereAlso/intoThis");
     }
 
 }


### PR DESCRIPTION
Enables prefixing with a relative path, so preview of include directives also work in IDEA