### PR TITLE
fixes: #118: Upon duplicate variable keys, last entry wins (#119)

### DIFF
--- a/src/main/java/io/whelk/asciidoc/TemplateMojo.java
+++ b/src/main/java/io/whelk/asciidoc/TemplateMojo.java
@@ -69,6 +69,7 @@ public class TemplateMojo extends AbstractMojo {
     Map<String, String> loadVars(List<String> strings) {
         String varRegex = "^:[\\w\\-]+:"; //includes dashes
         Pattern compile = Pattern.compile(varRegex);
+
         return strings.stream()
                 .map(x -> {
                     Matcher matcher = compile.matcher(x);
@@ -83,7 +84,8 @@ public class TemplateMojo extends AbstractMojo {
                     }
                 })
                 .filter(x -> x.size() == 2)
-                .collect(toMap(x -> x.get(0), x -> x.get(1)));
+                // when merging duplicates, last entry wins
+                .collect(toMap(x -> x.get(0), x -> x.get(1), (first, second) -> second));
     }
 
     private List<String> updateLines(List<String> lines) {

--- a/src/test/java/io/whelk/asciidoc/TemplateMojoTest.java
+++ b/src/test/java/io/whelk/asciidoc/TemplateMojoTest.java
@@ -47,13 +47,16 @@ public class TemplateMojoTest {
                 ":baseDir: relativeDirectory",
                 "some content",
                 ":Here you can see a weirdly used colon",
-                ":dash-var: dv"
+                ":dash-var: dv",
+                ":level-offset: +1",
+                ":level-offset: -1"
         ));
         Map<String, String> expected = Map.of(
                 "myVar", "4",
                 "noSpace", "5",
                 "baseDir", "relativeDirectory",
-                "dash-var", "dv");
+                "dash-var", "dv",
+                "level-offset", "-1");
         assertThat(vars).containsExactlyInAnyOrderEntriesOf(expected);
     }
 


### PR DESCRIPTION
Useful for situations when variables are modified, for example:

:leveloffset: +1
include::file1.adoc[]
:leveloffset: -1

See Supports leveloffset:
- #118